### PR TITLE
quick fix - patched datetime parser for news to avoid crashes

### DIFF
--- a/app/src/main/java/org/stypox/tridenta/extractor/DateTimeUtils.kt
+++ b/app/src/main/java/org/stypox/tridenta/extractor/DateTimeUtils.kt
@@ -2,7 +2,12 @@ package org.stypox.tridenta.extractor
 
 import java.io.IOException
 import java.time.*
+import java.time.chrono.IsoChronology
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
+import java.time.format.ResolverStyle
 import java.time.temporal.ChronoUnit
+import java.util.Locale
 
 val ROME_ZONE_ID: ZoneId = ZoneId.of("Europe/Rome")
 
@@ -22,6 +27,16 @@ fun dateTimeFromISOString(s: String?): OffsetDateTime? {
     } else {
         OffsetDateTime.parse(s).atZoneSameInstant(ROME_ZONE_ID).toOffsetDateTime()
     }
+}
+
+fun dateTimeFromISOStringBasicOffset(s: String): OffsetDateTime {
+    val format = DateTimeFormatterBuilder()
+        .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        .optionalStart()
+        .appendOffset("+HHmm", "+0000")
+        .toFormatter()
+
+    return OffsetDateTime.parse(s, format)
 }
 
 class ZonedTimeHelper(private var referenceDateTime: ZonedDateTime) {

--- a/app/src/main/java/org/stypox/tridenta/extractor/Parsers.kt
+++ b/app/src/main/java/org/stypox/tridenta/extractor/Parsers.kt
@@ -44,8 +44,8 @@ fun lineFromJSONObject(o: JSONObject): ExLine {
 fun newsItemFromJSONObject(o: JSONObject): ExNewsItem {
     return ExNewsItem(
         serviceType = o.getString("serviceType"),
-        startDate = dateTimeFromEpochString(o.getString("startDate")),
-        endDate = dateTimeFromEpochString(o.getString("endDate")),
+        startDate = dateTimeFromISOStringBasicOffset(o.getString("startDate")),
+        endDate = dateTimeFromISOStringBasicOffset(o.getString("endDate")),
         header = o.getString("header").trim(),
         details = o.getString("details").trim(),
         url = o.getString("url"),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.8.1"
+agp = "8.9.1"
 composeDestinations = "1.9.54"
 espressoCore = "3.6.1"
 hilt = "2.55"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
The API changed the route's news date time format from time since epoch to an ISO date time (with basic offset, no colon).

This is just a quick fix, further fixing is needed in order to avoid crashes during parsing.